### PR TITLE
Add backup reserve level control for DeltaPro3 (v1.4.0-beta1)

### DIFF
--- a/custom_components/ecoflow_api/number.py
+++ b/custom_components/ecoflow_api/number.py
@@ -7,12 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import (
-    PERCENTAGE,
-    UnitOfElectricCurrent,
-    UnitOfPower,
-    UnitOfTime,
-)
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfPower, UnitOfTime
 
 from .const import DEFAULT_POWER_STEP, DOMAIN, OPTS_POWER_STEP
 from .entity import EcoFlowBaseEntity
@@ -161,6 +156,18 @@ DELTA_PRO_3_NUMBER_DEFINITIONS = {
         "icon": "mdi:bluetooth",
         "mode": NumberMode.BOX,
     },
+    "backup_reserve_level": {
+        "name": "Backup Reserve Level",
+        "state_key": "backupReverseSoc",
+        "command_key": "cfgEnergyBackup",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "unit": PERCENTAGE,
+        "icon": "mdi:battery-lock",
+        "mode": NumberMode.SLIDER,
+        "nested_params": True,
+    },
 }
 
 
@@ -245,6 +252,19 @@ class EcoFlowNumber(EcoFlowBaseEntity, NumberEntity):
         # Convert to int for API
         int_value = int(value)
 
+        # Handle nested parameters for backup reserve level
+        if self._number_def.get("nested_params"):
+            # Special case for backup reserve level - needs nested structure
+            params = {
+                command_key: {
+                    "energyBackupStartSoc": int_value,
+                    "energyBackupEn": True
+                }
+            }
+        else:
+            # Standard simple parameter structure
+            params = {command_key: int_value}
+
         # Build command payload according to Delta Pro 3 API format
         payload = {
             "sn": device_sn,
@@ -254,7 +274,7 @@ class EcoFlowNumber(EcoFlowBaseEntity, NumberEntity):
             "cmdFunc": 254,
             "dest": 2,
             "needAck": True,
-            "params": {command_key: int_value},
+            "params": params,
         }
 
         try:


### PR DESCRIPTION
## 🆕 New Feature: Backup Reserve Level Control

- 🔋 **Backup Reserve Level Number Entity** - Add number entity to set backup reserve level on DeltaPro3
  - New `number.backup_reserve_level` entity for DeltaPro3 devices
  - Uses nested API structure: `cfgEnergyBackup` with `energyBackupStartSoc` and `energyBackupEn`
  - Compatible with existing `sensor.backup_reserve_soc` for reading current value
  - Slider control for easy adjustment (0-100%)
  - Special handling for nested parameters in API calls

## 🔧 Technical Implementation
- Added `nested_params` flag to number entity definitions for complex API structures
- Modified `async_set_native_value` to handle both simple and nested parameter formats
- Maintains backward compatibility with existing number entities
- Proper error handling and logging for debugging

## 🧪 Testing Notes
This is a pre-release for testing the backup reserve level functionality. Please test:
1. ✅ Number entity appears in Home Assistant for DeltaPro3 devices
2. ✅ Slider control shows current backup reserve level from sensor
3. ✅ Setting new value via slider updates the device
4. ✅ API response is handled correctly
5. ✅ Error handling works for invalid values

## ⚠️ Important
- Only affects DeltaPro3 devices
- Requires device firmware that supports backup reserve level setting
- Test with actual device to verify API compatibility

## 📋 Files Changed
- `number.py`: Added backup_reserve_level entity with nested API support
- `manifest.json`: Updated to v1.4.0-beta1
- Import formatting fixes applied

## 🐛 Bug Reports
Please report any issues on GitHub with:
- Device model and firmware version
- Home Assistant version
- Error logs from Home Assistant logs
- Steps to reproduce

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `backup_reserve_level` number entity for Delta Pro 3 with nested API parameter handling.
> 
> - **Number entities (Delta Pro 3)**:
>   - Add `backup_reserve_level` with slider (0–100%), unit `PERCENTAGE`, and icon `mdi:battery-lock`.
>   - Introduce `nested_params` flag in definitions to support complex API structures.
> - **Command handling**:
>   - Update `async_set_native_value` to build nested `params` for `cfgEnergyBackup` (`energyBackupStartSoc`, `energyBackupEn`) while preserving simple param path for others.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf251b26b0e04768729eb0aa50ac4ec46aec45d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->