### PR TITLE
Fix: Cascaded Stream AC Pro — slave device sensors showing 0

### DIFF
--- a/custom_components/ecoflow_api/sensor.py
+++ b/custom_components/ecoflow_api/sensor.py
@@ -3032,6 +3032,8 @@ STREAM_ULTRA_X_SENSOR_DEFINITIONS = {
     "battery_level": {
         "name": "Battery Level",
         "key": "cmsBattSoc",
+        "fallback_key": "actSoc",
+        "fallback_on_zero": True,
         "unit": PERCENTAGE,
         "device_class": SensorDeviceClass.BATTERY,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -3075,6 +3077,8 @@ STREAM_ULTRA_X_SENSOR_DEFINITIONS = {
     "system_load_power": {
         "name": "System Load Power",
         "key": "powGetSysLoad",
+        "fallback_key": "outputWatts",
+        "fallback_on_zero": True,
         "unit": UnitOfPower.WATT,
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -3100,6 +3104,7 @@ STREAM_ULTRA_X_SENSOR_DEFINITIONS = {
     "battery_power": {
         "name": "Battery Power",
         "key": "powGetBpCms",
+        "fallback_key": "powGetBpCms",
         "unit": UnitOfPower.WATT,
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -3873,7 +3878,11 @@ class EcoFlowSensor(EcoFlowBaseEntity, SensorEntity):
                 value = parent.get(parts[1])
 
         # Try fallback key if primary key has no data
-        if value is None or (isinstance(value, list) and all(v == 0 for v in value)):
+        # Also try fallback when value is 0/0.0 and fallback_on_zero is set
+        should_fallback = (value is None or 
+            (isinstance(value, list) and all(v == 0 for v in value)) or
+            (self._sensor_config.get("fallback_on_zero") and value == 0.0))
+        if should_fallback:
             fallback_key = self._sensor_config.get("fallback_key")
             if fallback_key:
                 value = self.coordinator.data.get(fallback_key)


### PR DESCRIPTION
Problem:
When two Stream AC Pro devices are cascaded (AI Mode), the slave device reports 0.0 for all CMS-level fields (cmsBattSoc, powGetSysLoad, powGetBpCms) because only the master aggregates CMS data. The device-level fields (actSoc, outputWatts) contain correct values.

Changes:

Extended fallback logic to also trigger on 0.0 (not just None) via new fallback_on_zero flag Added actSoc as fallback for cmsBattSoc (Battery Level) Added outputWatts as fallback for powGetSysLoad (System Load Power) Tested with: 2x Stream AC Pro in cascade mode (v1.9.4), master reports correct CMS values, slave now correctly falls back to BMS/device-level values.