### PR TITLE
fix: Power Off button API error 1008

### DIFF
--- a/custom_components/ecoflow_api/button.py
+++ b/custom_components/ecoflow_api/button.py
@@ -119,7 +119,7 @@ class EcoFlowButton(EcoFlowBaseEntity, ButtonEntity):
             "cmdFunc": 254,
             "dest": 2,
             "needAck": True,
-            "params": {command_key: 1},
+            "params": {command_key: True},
         }
 
         try:


### PR DESCRIPTION
## Summary

Fixes #21 - Power Off button generates API error (code 1008)

## Problem

The Power Off button was sending `cfgPowerOff: 1` (integer) but the EcoFlow API expects `cfgPowerOff: true` (boolean).

## Solution

Changed the payload parameter from `1` to `True` in `button.py:122` to match the API specification:

```python
# Before
"params": {command_key: 1}

# After  
"params": {command_key: True}
```

## API Reference

From EcoFlow Delta Pro 3 documentation:
```json
{
    "sn": "MR51ZAS2PG330026",
    "cmdId": 17,
    "dirDest": 1,
    "dirSrc": 1,
    "cmdFunc": 254,
    "dest": 2,
    "needAck": true,
    "params": {
        "cfgPowerOff": true
    }
}
```

## Test plan

- [ ] Verify syntax with `python -m py_compile` ✅
- [ ] Test Power Off button on actual device