### PR TITLE
fix: Stream Ultra X binary sensors, Delta 2 charge state, MQTT watchdog (#42 #41 #39)

### DIFF
--- a/custom_components/ecoflow_api/binary_sensor.py
+++ b/custom_components/ecoflow_api/binary_sensor.py
@@ -749,10 +749,11 @@ class EcoFlowBinarySensor(EcoFlowBaseEntity, BinarySensorEntity):
             return None
 
         # Handle derived sensors
-        if self._is_derived and self._derive_from and self._derive_condition:
-            source_value = self.coordinator.data.get(self._derive_from)
-            if source_value is None and "." in self._derive_from:
-                parts = self._derive_from.split(".", 1)
+        if self._is_derived and self._derive_condition:
+            source_key = self._derive_from or self._data_key
+            source_value = self.coordinator.data.get(source_key)
+            if source_value is None and "." in source_key:
+                parts = source_key.split(".", 1)
                 parent = self.coordinator.data.get(parts[0])
                 if isinstance(parent, dict):
                     source_value = parent.get(parts[1])

--- a/custom_components/ecoflow_api/hybrid_coordinator.py
+++ b/custom_components/ecoflow_api/hybrid_coordinator.py
@@ -23,6 +23,12 @@ from .mqtt_client import EcoFlowMQTTClient
 
 _LOGGER = logging.getLogger(__name__)
 
+# Force MQTT reconnect if no message arrives for this many seconds while the
+# connection is reported as alive. EcoFlow's broker sometimes stalls pushes
+# without disconnecting the TCP socket, so paho's reconnect logic never fires.
+MQTT_SILENCE_THRESHOLD = 180
+MQTT_WATCHDOG_INTERVAL = 60
+
 
 class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
     """Hybrid coordinator using both REST API and MQTT.
@@ -84,7 +90,15 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
         # Track last REST update time for interval verification
         self._last_rest_update: float | None = None
 
-        
+        # Track last MQTT message time for watchdog-based silent-drop detection.
+        # EcoFlow broker occasionally throttles clients without sending a disconnect,
+        # so paho's own reconnect does not trigger. The watchdog forces a reconnect
+        # when no message arrives for longer than MQTT_SILENCE_THRESHOLD seconds.
+        self._last_mqtt_message_time: float | None = None
+        self._mqtt_watchdog_timer: asyncio.TimerHandle | None = None
+        self._mqtt_watchdog_task: asyncio.Task | None = None
+        self._shutting_down = False
+
         # Timer for periodic REST updates (independent of MQTT)
         self._rest_update_timer: asyncio.TimerHandle | None = None
         
@@ -163,6 +177,8 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
                 self._mqtt_connected = True
                 self._use_mqtt = True
                 self._logged_mqtt_connected = True
+                self._last_mqtt_message_time = time.time()
+                self._schedule_mqtt_watchdog()
                 _LOGGER.info(
                     "✅ MQTT connected to broker for device %s (hybrid mode: MQTT + REST every %ds)",
                     self.device_sn[-4:],
@@ -183,10 +199,25 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator."""
+        self._shutting_down = True
+
         # Cancel REST update timer
         if self._rest_update_timer:
             self._rest_update_timer.cancel()
             self._rest_update_timer = None
+
+        # Cancel MQTT watchdog timer and await any in-flight tick so it cannot
+        # race with the MQTT client teardown below.
+        if self._mqtt_watchdog_timer:
+            self._mqtt_watchdog_timer.cancel()
+            self._mqtt_watchdog_timer = None
+        if self._mqtt_watchdog_task and not self._mqtt_watchdog_task.done():
+            self._mqtt_watchdog_task.cancel()
+            try:
+                await self._mqtt_watchdog_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._mqtt_watchdog_task = None
 
         # Disconnect MQTT
         if self._mqtt_client:
@@ -271,6 +302,62 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
             self._schedule_rest_update()
 
 
+    def _schedule_mqtt_watchdog(self) -> None:
+        """Schedule next MQTT silence check."""
+        if self._shutting_down:
+            return
+        if self._mqtt_watchdog_timer:
+            self._mqtt_watchdog_timer.cancel()
+
+        def _fire() -> None:
+            if self._shutting_down:
+                return
+            if not self.hass.loop.is_running() or self.hass.loop.is_closed():
+                return
+            self._mqtt_watchdog_task = self.hass.async_create_task(
+                self._mqtt_watchdog_tick()
+            )
+
+        self._mqtt_watchdog_timer = self.hass.loop.call_later(
+            MQTT_WATCHDOG_INTERVAL, _fire
+        )
+
+    async def _mqtt_watchdog_tick(self) -> None:
+        """Force MQTT reconnect if the broker has gone silent while connected."""
+        try:
+            if self._shutting_down:
+                return
+            if not self._mqtt_client or not self._mqtt_connected:
+                return
+
+            last = self._last_mqtt_message_time
+            if last is None:
+                return
+
+            silence = time.time() - last
+            if silence < MQTT_SILENCE_THRESHOLD:
+                return
+
+            _LOGGER.warning(
+                "⚠️ MQTT silent for %.0fs on device %s (threshold=%ds) — forcing reconnect",
+                silence,
+                self.device_sn[-4:],
+                MQTT_SILENCE_THRESHOLD,
+            )
+
+            try:
+                await self._mqtt_client.async_disconnect()
+            except Exception as err:
+                _LOGGER.debug("MQTT disconnect during watchdog recovery: %s", err)
+
+            if self._shutting_down:
+                return
+            self._mqtt_connected = False
+            await self._async_setup_mqtt()
+        finally:
+            if not self._shutting_down:
+                self._schedule_mqtt_watchdog()
+
     def _handle_mqtt_status(self, connected: bool) -> None:
         """Handle MQTT connection status change.
 
@@ -282,6 +369,7 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
 
         if connected and not was_connected:
             self._mqtt_reconnect_count += 1
+            self._last_mqtt_message_time = time.time()
             if self._mqtt_reconnect_count > 1:
                 _LOGGER.info(
                     "🔄 MQTT reconnected for device %s (reconnect #%d)",
@@ -308,6 +396,7 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
             # MQTT client already extracts params from quota topic
             # So payload here is the actual device data
             mqtt_data = payload
+            self._last_mqtt_message_time = time.time()
             
             # Debug logging (only if logger level is DEBUG)
             if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/custom_components/ecoflow_api/sensor.py
+++ b/custom_components/ecoflow_api/sensor.py
@@ -1679,8 +1679,8 @@ DELTA_2_SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
         "icon": "mdi:battery-sync",
-        "options": ["not_charging", "charging"],
-        "value_map": {0: "not_charging", 1: "charging"},
+        "options": ["not_charging", "charging", "discharging", "unknown"],
+        "value_map": {0: "not_charging", 1: "charging", 2: "discharging", "default": "unknown"},
     },
     "bms_target_soc": {
         "name": "Battery Target SOC",
@@ -2022,8 +2022,8 @@ DELTA_2_SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
         "icon": "mdi:battery-charging",
-        "options": ["not_charging", "charging"],
-        "value_map": {0: "not_charging", 1: "charging"},
+        "options": ["not_charging", "charging", "discharging", "unknown"],
+        "value_map": {0: "not_charging", 1: "charging", 2: "discharging", "default": "unknown"},
     },
     "ems_chg_cmd": {
         "name": "EMS Charge Command",


### PR DESCRIPTION
## Summary
Three targeted bug fixes for open issues, each in its own commit.

- **#42** — Stream Ultra X binary sensors (Battery Charging/Discharging, Solar Generating, Grid Consuming/Feed-in) were stuck on *Unknown*. The device's sensor defs use `derived: True` + `key` without an explicit `derive_from`, and the runtime required `derive_from` to be truthy, so wattage readings were treated as raw booleans. The runtime now falls back to `key` when `derive_from` is unset.
- **#41** — Delta 2 `bms_chg_state` / `ems_chg_state` returned a raw `"2"` (discharging) that wasn't in the ENUM options, triggering Home Assistant's ENUM validation error and cascading into unrelated `number/set_value` actions. Options/value_map now cover `2 → discharging` and a `default → unknown` for any future unmapped state. `not_charging` is kept for state `0` so existing automations still work.
- **#39** — EcoFlow's MQTT broker sometimes silently throttles idle clients without closing the TCP socket, so paho's auto-reconnect never fires and live updates freeze until the integration is reloaded. Added a silence-detection watchdog (default 180 s silence threshold, 60 s check interval) that forces a full MQTT teardown + `_async_setup_mqtt()` when the connection is reported alive but quiet.

## Test plan
- [ ] Stream Ultra X: confirm Battery Charging/Discharging, Solar Generating, Grid Feed-in/Consuming toggle correctly based on `powGetBpCms` / `powGetPvSum` / `gridConnectionPower`.
- [ ] Delta 2: confirm `battery_charge_state` now reports `discharging` without raising "state value '2' is not in the list of options" and that `number/set_value` actions succeed again.
- [ ] Any device: leave HA running on an idle EcoFlow and watch the logs — after ~3 min of MQTT silence you should see `⚠️ MQTT silent for … — forcing reconnect` followed by a fresh `✅ MQTT connected`.
- [ ] Verify clean shutdown with `Settings → Reload` and `Developer Tools → Services → homeassistant.restart`: no "Event loop is closed" warnings, no lingering timers.

Closes #42
Closes #41
Closes #39