### PR TITLE
feat: per-port voltage/current/error-code sensors for Delta Pro 3

### DIFF
--- a/custom_components/ecoflow_api/sensor.py
+++ b/custom_components/ecoflow_api/sensor.py
@@ -442,6 +442,68 @@ DELTA_PRO_3_SENSOR_DEFINITIONS = {
         "icon": "mdi:battery-charging",
     },
     # ============================================================================
+    # Per-port electrical telemetry (exposed by EcoFlow API 2026-04 onwards)
+    # ============================================================================
+    "plug_in_info_4p81_vol": {
+        "name": "4.8V Port 1 Voltage",
+        "key": "plugInInfo4p81Vol",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:flash",
+    },
+    "plug_in_info_4p81_amp": {
+        "name": "4.8V Port 1 Current",
+        "key": "plugInInfo4p81Amp",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:current-dc",
+    },
+    "plug_in_info_4p81_err_code": {
+        "name": "4.8V Port 1 Error Code",
+        "key": "plugInInfo4p81ErrCode",
+        "unit": None,
+        "device_class": None,
+        "state_class": None,
+        "icon": "mdi:alert-circle",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "plug_in_info_4p82_vol": {
+        "name": "4.8V Port 2 Voltage",
+        "key": "plugInInfo4p82Vol",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:flash",
+    },
+    "plug_in_info_4p82_amp": {
+        "name": "4.8V Port 2 Current",
+        "key": "plugInInfo4p82Amp",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:current-dc",
+    },
+    "plug_in_info_4p82_err_code": {
+        "name": "4.8V Port 2 Error Code",
+        "key": "plugInInfo4p82ErrCode",
+        "unit": None,
+        "device_class": None,
+        "state_class": None,
+        "icon": "mdi:alert-circle",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "plug_in_info_5p8_err_code": {
+        "name": "5.8V Port Error Code",
+        "key": "plugInInfo5p8ErrCode",
+        "unit": None,
+        "device_class": None,
+        "state_class": None,
+        "icon": "mdi:alert-circle",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    # ============================================================================
     # POWER - Output
     # ============================================================================
     "pow_out_sum_w": {
@@ -489,6 +551,38 @@ DELTA_PRO_3_SENSOR_DEFINITIONS = {
         "key": "powGet24v",
         "unit": UnitOfPower.WATT,
         "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:current-dc",
+    },
+    "plug_in_info_12v_vol": {
+        "name": "12V DC Output Voltage",
+        "key": "plugInInfo12vVol",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:flash",
+    },
+    "plug_in_info_12v_amp": {
+        "name": "12V DC Output Current",
+        "key": "plugInInfo12vAmp",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "device_class": SensorDeviceClass.CURRENT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:current-dc",
+    },
+    "plug_in_info_24v_vol": {
+        "name": "24V DC Output Voltage",
+        "key": "plugInInfo24vVol",
+        "unit": UnitOfElectricPotential.VOLT,
+        "device_class": SensorDeviceClass.VOLTAGE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:flash",
+    },
+    "plug_in_info_24v_amp": {
+        "name": "24V DC Output Current",
+        "key": "plugInInfo24vAmp",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "device_class": SensorDeviceClass.CURRENT,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:current-dc",
     },
@@ -4394,6 +4488,12 @@ class EcoFlowSensor(EcoFlowBaseEntity, SensorEntity):
         self._attr_device_class = sensor_config.get("device_class")
         self._attr_state_class = sensor_config.get("state_class")
         self._attr_icon = sensor_config.get("icon")
+
+        # Optional entity category (e.g. diagnostic) — lets definitions hide
+        # low-level data like error codes behind HA's diagnostic section.
+        entity_category = sensor_config.get("entity_category")
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
 
         # For ENUM sensors, set options
         if sensor_config.get("device_class") == SensorDeviceClass.ENUM:


### PR DESCRIPTION
## Summary
Expose the per-port electrical telemetry keys that EcoFlow added alongside the recovered `plugInInfo4p81Resv` block in their 2026-04 API update (discovered while investigating #38).

**New sensors on Delta Pro 3:**

| Sensor | API key | Unit |
|---|---|---|
| 4.8V Port 1 Voltage | `plugInInfo4p81Vol` | V |
| 4.8V Port 1 Current | `plugInInfo4p81Amp` | A |
| 4.8V Port 1 Error Code | `plugInInfo4p81ErrCode` | — (diagnostic) |
| 4.8V Port 2 Voltage | `plugInInfo4p82Vol` | V |
| 4.8V Port 2 Current | `plugInInfo4p82Amp` | A |
| 4.8V Port 2 Error Code | `plugInInfo4p82ErrCode` | — (diagnostic) |
| 5.8V Port Error Code | `plugInInfo5p8ErrCode` | — (diagnostic) |
| 12V DC Output Voltage | `plugInInfo12vVol` | V |
| 12V DC Output Current | `plugInInfo12vAmp` | A |
| 24V DC Output Voltage | `plugInInfo24vVol` | V |
| 24V DC Output Current | `plugInInfo24vAmp` | A |

Error-code sensors use `EntityCategory.DIAGNOSTIC` so they land under HA's diagnostic section instead of the main entity list.

**Side fix:** the base `EcoFlowSensor` now reads `entity_category` from the sensor definition. The existing `entity_category` hints in `DELTA_PRO_ULTRA_SENSOR_DEFINITIONS` were previously set in configs but never applied to the entity.

## Scope
Intentionally narrow — ~200 new API keys appeared in the user's diagnostic dump, but most are low-level inverter/MPPT/BMS internals that don't add user-visible value. This PR covers the eleven keys most directly useful for monitoring (per-port electrical + error codes). Further fine-grained BMS and inverter telemetry can land in follow-up PRs if users request it.

## Test plan
- [ ] Install on a Delta Pro 3 and confirm the new Voltage/Current sensors populate (non-zero values appear when something is plugged into the port).
- [ ] Confirm the three Error Code sensors appear under the device's **Diagnostic** section in HA, not the main sensor list.
- [ ] Confirm no duplicate entity-name warnings in logs.

Follow-up to #38.