### PR TITLE
fix: auto-refresh MQTT creds and ACK-verify commands (issue #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.4] - 2026-04-20
+
+### 🐛 Bug Fixes
+
+- **Fixed Stream Ultra X "Unknown" entities after EcoFlow maintenance (issue #45)** —
+  MQTT credentials are now automatically re-fetched from the EcoFlow REST API
+  when the broker rejects the stored credentials (CONNACK rc=4 / rc=5), with a
+  5-minute cooldown to avoid hammering the API. Previously the integration
+  stayed stuck on stale credentials after EcoFlow rotated them during their
+  maintenance window.
+- **Fixed AC1 Switch silent failure on Stream Ultra X** — switch commands with
+  `needAck` now wait up to 5s for a matching `set_reply` MQTT message. If no
+  ACK arrives (broker silently dropped the publish), the hybrid coordinator
+  falls back to the REST API instead of reporting success while the device
+  ignored the command.
+- **Faster broker-stall recovery for Stream series** — MQTT silence threshold
+  lowered from 180s to 90s specifically for Stream Ultra X, matching the
+  broker's observed stall behaviour during EcoFlow maintenance windows.
+
+---
+
 ## [1.8.4] - 2026-02-08
 
 ### 🐛 Bug Fixes

--- a/custom_components/ecoflow_api/hybrid_coordinator.py
+++ b/custom_components/ecoflow_api/hybrid_coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .api import EcoFlowApiClient, EcoFlowApiError
+from .const import DEVICE_TYPE_STREAM_ULTRA_X
 from .coordinator import EcoFlowDataCoordinator
 from .data_holder import BoundFifoList
 from .mqtt_client import EcoFlowMQTTClient
@@ -27,7 +28,17 @@ _LOGGER = logging.getLogger(__name__)
 # connection is reported as alive. EcoFlow's broker sometimes stalls pushes
 # without disconnecting the TCP socket, so paho's reconnect logic never fires.
 MQTT_SILENCE_THRESHOLD = 180
+# Stream Ultra X devices have shown silent broker stalls during EcoFlow
+# maintenance windows (see issue #45 — 2026-04-20). Catch them faster.
+MQTT_SILENCE_THRESHOLD_STREAM = 90
 MQTT_WATCHDOG_INTERVAL = 60
+
+# Rate limit on credential re-fetches triggered by broker auth failures,
+# so a persistently-wrong credential does not hammer the REST API.
+MQTT_CREDENTIAL_REFRESH_COOLDOWN = 300
+# Per-command ACK timeout for MQTT set_reply. If the device does not confirm
+# within this window the hybrid coordinator falls back to the REST API.
+MQTT_COMMAND_ACK_TIMEOUT = 5.0
 
 
 class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
@@ -86,6 +97,14 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
         self._mqtt_connected = False
         self._use_mqtt = False
         self._mqtt_reconnect_count = 0
+        self._last_credential_refresh: float = 0.0
+        self._credential_refresh_task: asyncio.Task | None = None
+        # Stream series is more sensitive to broker stalls after EcoFlow maintenance.
+        self._mqtt_silence_threshold = (
+            MQTT_SILENCE_THRESHOLD_STREAM
+            if device_type == DEVICE_TYPE_STREAM_ULTRA_X
+            else MQTT_SILENCE_THRESHOLD
+        )
 
         # Track last REST update time for interval verification
         self._last_rest_update: float | None = None
@@ -168,6 +187,8 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
                 on_message_callback=self._handle_mqtt_message,
                 on_status_callback=self._handle_mqtt_status,
                 certificate_account=self.certificate_account,
+                on_auth_failure_callback=self._handle_mqtt_auth_failure,
+                loop=self.hass.loop,
             )
             
             # Try to connect
@@ -219,6 +240,15 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
                 pass
         self._mqtt_watchdog_task = None
 
+        # Cancel any in-flight credential refresh
+        if self._credential_refresh_task and not self._credential_refresh_task.done():
+            self._credential_refresh_task.cancel()
+            try:
+                await self._credential_refresh_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._credential_refresh_task = None
+
         # Disconnect MQTT
         if self._mqtt_client:
             await self._mqtt_client.async_disconnect()
@@ -243,10 +273,18 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
             command.get("params", {}),
         )
 
-        # Try MQTT first (faster, real-time)
+        # Try MQTT first (faster, real-time). Commands with ``needAck`` expect a
+        # set_reply — wait for it so we can distinguish real success from a
+        # broker that ACKed the publish but never delivered it to the device
+        # (observed on Stream Ultra X during EcoFlow maintenance; see issue #45).
         if self._mqtt_connected and self._mqtt_client:
+            ack_timeout = (
+                MQTT_COMMAND_ACK_TIMEOUT if command.get("needAck") else None
+            )
             try:
-                success = await self._mqtt_client.async_publish_command(command)
+                success = await self._mqtt_client.async_publish_command(
+                    command, ack_timeout=ack_timeout
+                )
                 if success:
                     _LOGGER.debug("Command sent via MQTT for %s", self.device_sn[-4:])
                     return True
@@ -335,14 +373,14 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
                 return
 
             silence = time.time() - last
-            if silence < MQTT_SILENCE_THRESHOLD:
+            if silence < self._mqtt_silence_threshold:
                 return
 
             _LOGGER.warning(
                 "⚠️ MQTT silent for %.0fs on device %s (threshold=%ds) — forcing reconnect",
                 silence,
                 self.device_sn[-4:],
-                MQTT_SILENCE_THRESHOLD,
+                self._mqtt_silence_threshold,
             )
 
             try:
@@ -381,6 +419,95 @@ class EcoFlowHybridCoordinator(EcoFlowDataCoordinator):
                 "⚠️ MQTT disconnected for device %s, commands will use REST API fallback",
                 self.device_sn[-4:],
             )
+
+    def _handle_mqtt_auth_failure(self, rc: int) -> None:
+        """Broker rejected our MQTT credentials — schedule a refresh.
+
+        Runs in paho's thread, so we bounce the actual work onto the main loop.
+        Rate-limited to avoid hammering the EcoFlow REST API when credentials
+        are genuinely invalid (e.g. API keys revoked).
+        """
+        if self._shutting_down:
+            return
+        self.hass.loop.call_soon_threadsafe(self._schedule_credential_refresh, rc)
+
+    def _schedule_credential_refresh(self, rc: int) -> None:
+        """Kick off credential re-fetch if not already running and not rate-limited."""
+        if self._shutting_down:
+            return
+        if self._credential_refresh_task and not self._credential_refresh_task.done():
+            return
+
+        now = time.time()
+        if now - self._last_credential_refresh < MQTT_CREDENTIAL_REFRESH_COOLDOWN:
+            _LOGGER.debug(
+                "Skipping MQTT credential refresh for %s (cooldown; last=%.0fs ago, rc=%d)",
+                self.device_sn[-4:],
+                now - self._last_credential_refresh,
+                rc,
+            )
+            return
+
+        _LOGGER.warning(
+            "🔑 MQTT broker rejected credentials (rc=%d) for %s — refreshing from REST API",
+            rc,
+            self.device_sn[-4:],
+        )
+        self._last_credential_refresh = now
+        self._credential_refresh_task = self.hass.async_create_task(
+            self._async_refresh_mqtt_credentials()
+        )
+
+    async def _async_refresh_mqtt_credentials(self) -> None:
+        """Fetch fresh MQTT credentials and reconnect the client.
+
+        EcoFlow rotates broker credentials during maintenance windows; without
+        this, the integration is stuck with stale credentials until the user
+        manually reloads it (see issue #45).
+        """
+        try:
+            creds = await self.client.get_mqtt_credentials()
+        except Exception as err:
+            _LOGGER.error(
+                "Failed to refresh MQTT credentials for %s: %s",
+                self.device_sn[-4:],
+                err,
+            )
+            return
+
+        new_account = creds.get("certificateAccount")
+        new_password = creds.get("certificatePassword")
+        if not new_account or not new_password:
+            _LOGGER.error(
+                "MQTT credential refresh for %s returned empty values",
+                self.device_sn[-4:],
+            )
+            return
+
+        unchanged = (
+            new_account == self.mqtt_username
+            and new_password == self.mqtt_password
+        )
+        self.mqtt_username = new_account
+        self.mqtt_password = new_password
+        self.certificate_account = new_account
+
+        if self._mqtt_client:
+            try:
+                await self._mqtt_client.async_disconnect()
+            except Exception as err:
+                _LOGGER.debug("Error disconnecting stale MQTT client: %s", err)
+            self._mqtt_client = None
+
+        self._mqtt_connected = False
+        if unchanged:
+            _LOGGER.warning(
+                "MQTT credential refresh for %s returned the same values — "
+                "broker rejection is not a rotation. Will retry on next cooldown.",
+                self.device_sn[-4:],
+            )
+
+        await self._async_setup_mqtt()
 
     def _handle_mqtt_message(self, payload: dict[str, Any]) -> None:
         """Handle MQTT message from device.

--- a/custom_components/ecoflow_api/manifest.json
+++ b/custom_components/ecoflow_api/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/TarasKhust/ecoflow-api-mqtt/issues",
   "requirements": ["aiohttp>=3.8.0", "paho-mqtt>=1.6.1"],
-  "version": "1.10.3"
+  "version": "1.10.4"
 }

--- a/custom_components/ecoflow_api/mqtt_client.py
+++ b/custom_components/ecoflow_api/mqtt_client.py
@@ -46,6 +46,8 @@ class EcoFlowMQTTClient:
         on_message_callback: Callable[[dict[str, Any]], None] | None = None,
         on_status_callback: Callable[[bool], None] | None = None,
         certificate_account: str | None = None,
+        on_auth_failure_callback: Callable[[int], None] | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         """Initialize MQTT client.
 
@@ -56,16 +58,24 @@ class EcoFlowMQTTClient:
             on_message_callback: Callback function for received messages
             on_status_callback: Callback function for connection status changes (True=connected)
             certificate_account: Certificate account/user_id for topics (if None, uses username)
+            on_auth_failure_callback: Called with the MQTT CONNACK code when the broker
+                rejects our credentials (rc=4 bad creds, rc=5 not authorized). The
+                coordinator uses this signal to re-fetch fresh credentials from the
+                EcoFlow API after maintenance-window rotations.
+            loop: Event loop to dispatch ACK futures on (required for ACK tracking).
         """
         self.username = username
         self.password = password
         self.device_sn = device_sn
         self.on_message_callback = on_message_callback
         self.on_status_callback = on_status_callback
+        self.on_auth_failure_callback = on_auth_failure_callback
+        self._loop = loop
 
         self._client: mqtt.Client | None = None
         self._connected = False
         self._reconnect_task: asyncio.Task | None = None
+        self._pending_acks: dict[int, asyncio.Future[dict[str, Any]]] = {}
         
         # MQTT topics (correct format: /open/${certificateAccount}/${sn}/...)
         # certificateAccount is typically the user_id (not email)
@@ -148,7 +158,11 @@ class EcoFlowMQTTClient:
         self._connected = False
         _LOGGER.info("Disconnected from MQTT broker for device %s", self.device_sn)
 
-    async def async_publish_command(self, command: dict[str, Any]) -> bool:
+    async def async_publish_command(
+        self,
+        command: dict[str, Any],
+        ack_timeout: float | None = None,
+    ) -> bool:
         """Publish command to device via MQTT set topic.
 
         Ensures the payload has required MQTT fields (id, version) that
@@ -156,14 +170,21 @@ class EcoFlowMQTTClient:
 
         Args:
             command: Command payload (REST or MQTT format)
+            ack_timeout: If set, wait up to this many seconds for a matching
+                ``set_reply`` message. Returns False when the timeout elapses
+                or the reply indicates failure — letting the caller fall back
+                to the REST API.
 
         Returns:
-            True if published successfully, False otherwise
+            True if the command was published (and acknowledged when
+            ``ack_timeout`` was provided), False otherwise.
         """
         if not self._connected or not self._client:
             _LOGGER.warning("Cannot publish command: MQTT not connected")
             return False
 
+        ack_future: asyncio.Future[dict[str, Any]] | None = None
+        cmd_id: int | None = None
         try:
             # Ensure MQTT-required fields are present
             mqtt_command = dict(command)
@@ -181,6 +202,11 @@ class EcoFlowMQTTClient:
                 if "timestamp" not in mqtt_command:
                     mqtt_command["timestamp"] = int(time.time() * 1000)
 
+            cmd_id = int(mqtt_command["id"])
+            if ack_timeout is not None and self._loop is not None:
+                ack_future = self._loop.create_future()
+                self._pending_acks[cmd_id] = ack_future
+
             payload = json.dumps(mqtt_command)
             _LOGGER.debug(
                 "MQTT publish to %s: %s",
@@ -189,15 +215,47 @@ class EcoFlowMQTTClient:
             )
             result = self._client.publish(self._set_topic, payload, qos=1)
 
-            if result.rc == mqtt.MQTT_ERR_SUCCESS:
-                return True
-            else:
+            if result.rc != mqtt.MQTT_ERR_SUCCESS:
                 _LOGGER.error("Failed to publish command: rc=%s", result.rc)
                 return False
+
+            if ack_future is None:
+                return True
+
+            try:
+                reply = await asyncio.wait_for(ack_future, timeout=ack_timeout)
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "MQTT command %s for %s timed out after %.1fs (no set_reply); "
+                    "falling back to REST",
+                    cmd_id,
+                    self.device_sn[-4:],
+                    ack_timeout,
+                )
+                return False
+
+            # Stream Ultra X: {"result": 0} success, non-zero = failure.
+            # Delta Pro 3: {"configOk": true}. Delta 2/Plug: {"ack": 0}.
+            if (
+                reply.get("result") == 0
+                or reply.get("configOk") is True
+                or reply.get("ack") == 0
+            ):
+                return True
+            _LOGGER.warning(
+                "MQTT command %s for %s rejected by device: %s",
+                cmd_id,
+                self.device_sn[-4:],
+                reply,
+            )
+            return False
 
         except Exception as err:
             _LOGGER.error("Error publishing command: %s", err)
             return False
+        finally:
+            if cmd_id is not None:
+                self._pending_acks.pop(cmd_id, None)
 
     def _on_connect(
         self,
@@ -256,6 +314,15 @@ class EcoFlowMQTTClient:
                 self._quota_topic,
             )
 
+            # rc=4 (bad credentials) / rc=5 (not authorized) typically mean the broker
+            # rotated credentials on us (e.g. EcoFlow maintenance window). Let the
+            # coordinator decide whether to re-fetch them from the REST API.
+            if rc in (4, 5) and self.on_auth_failure_callback is not None:
+                try:
+                    self.on_auth_failure_callback(rc)
+                except Exception as err:
+                    _LOGGER.error("MQTT auth-failure callback raised: %s", err)
+
     def _on_disconnect(
         self,
         client: mqtt.Client,
@@ -264,6 +331,19 @@ class EcoFlowMQTTClient:
     ) -> None:
         """Handle MQTT disconnection."""
         self._connected = False
+
+        # Fail any in-flight ACK waiters so their callers can fall back to REST
+        # rather than blocking for the full timeout.
+        if self._pending_acks and self._loop is not None:
+            pending = list(self._pending_acks.values())
+            self._pending_acks.clear()
+            for future in pending:
+                if not future.done():
+                    self._loop.call_soon_threadsafe(
+                        lambda f=future: (
+                            not f.done() and f.cancel()
+                        )
+                    )
 
         # MQTT disconnect reason codes
         disconnect_reasons = {
@@ -332,6 +412,18 @@ class EcoFlowMQTTClient:
                     _LOGGER.debug("Command reply OK for %s (id=%s): %s", self.device_sn[-4:], reply_id, reply_data)
                 else:
                     _LOGGER.warning("Command reply for %s (id=%s): %s", self.device_sn[-4:], reply_id, payload)
+
+                # Resolve a pending ACK future (if any) so async_publish_command can
+                # distinguish real success from a silently-dropped publish. This runs
+                # in paho's thread, so hop back onto the main loop.
+                if isinstance(reply_id, int) and self._loop is not None:
+                    future = self._pending_acks.get(reply_id)
+                    if future is not None and not future.done():
+                        self._loop.call_soon_threadsafe(
+                            lambda f=future, d=reply_data: (
+                                not f.done() and f.set_result(d)
+                            )
+                        )
                 
             else:
                 # Unknown topic


### PR DESCRIPTION
## Summary

Fixes #45 — after EcoFlow's 2026-04-20 maintenance window, Stream Ultra X devices were left with stale MQTT credentials and the AC1 Switch silently failed (command reached broker but never the device).

- **Auto-refresh MQTT credentials on auth failure** — `EcoFlowMQTTClient` now fires a callback when the broker returns CONNACK rc=4 (bad credentials) or rc=5 (not authorized). The hybrid coordinator re-fetches fresh credentials from the REST API and reconnects, rate-limited to once every 5 minutes so we never hammer the API.
- **ACK-verify MQTT commands** — `async_publish_command` optionally awaits the matching `set_reply` (keyed by command `id`) for up to 5s. If no ACK arrives or the device reports failure, the hybrid coordinator falls back to the REST API instead of reporting success while the command was silently dropped.
- **Faster stall recovery for Stream series** — silence threshold reduced from 180s to 90s for Stream Ultra X, matching the broker's observed stall behaviour during maintenance.
- Release: `v1.10.4`, CHANGELOG updated.

## Test plan

- [ ] Reproduce issue #45 on Stream Ultra X: verify entities recover without reloading the integration after EcoFlow rotates broker credentials
- [ ] Toggle AC1 Switch while MQTT is connected: command should succeed (set_reply with `result:0`)
- [ ] Toggle AC1 Switch with a simulated broker stall (drop packets): command should fall back to REST after 5s and the device should still receive it
- [ ] Check logs for the new `🔑 MQTT broker rejected credentials (rc=…) — refreshing` line and verify the 5-minute cooldown is honoured on repeated failures
- [ ] Confirm no regression for Delta Pro 3, Delta 2, Delta Pro Ultra command paths (ACK wait only activates when `needAck: true`)

https://claude.ai/code/session_015Bx1QrqMzcsbMUzaZZqAQv