### PR TITLE
fix: skip Stream Ultra X switches when relay state key is missing (issue #45 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.5] - 2026-04-20
+
+### 🐛 Bug Fixes
+
+- **Fixed AC2 switch validation error on Stream Ultra X (follow-up to issue #45)** —
+  EcoFlow's BKW docs specify that in multi-device BKW systems AC1 and AC2
+  relays can live on different physical devices, so sending
+  `cfgRelay{2,3}Onoff` to a device that does not own the corresponding relay
+  is rejected by the REST API with validation error 8524. The integration
+  now skips creating a Stream Ultra X switch entity if the device's
+  `/quota/all` response does not include the corresponding `relay2Onoff` /
+  `relay3Onoff` / `feedGridMode` key, so no-op switches never reach the UI.
+  A full multi-device BKW topology (main SN + relay routing) will follow as
+  a separate enhancement.
+
+---
+
 ## [1.10.4] - 2026-04-20
 
 ### 🐛 Bug Fixes

--- a/custom_components/ecoflow_api/manifest.json
+++ b/custom_components/ecoflow_api/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/TarasKhust/ecoflow-api-mqtt/issues",
   "requirements": ["aiohttp>=3.8.0", "paho-mqtt>=1.6.1"],
-  "version": "1.10.4"
+  "version": "1.10.5"
 }

--- a/custom_components/ecoflow_api/switch.py
+++ b/custom_components/ecoflow_api/switch.py
@@ -476,6 +476,21 @@ async def async_setup_entry(
                 )
             )
         elif is_stream:
+            # In multi-device BKW systems AC1 and AC2 relays can live on
+            # different physical devices (see issue #45 and EcoFlow BKW docs).
+            # If this device's quota does not report the relay's state key,
+            # sending cfgRelay{2,3}Onoff here would be rejected by the REST
+            # API with validation error 8524 — so we skip creating the entity.
+            state_key = switch_def.get("state_key")
+            quota = coordinator.data or {}
+            if state_key and state_key not in quota:
+                _LOGGER.debug(
+                    "Skipping Stream switch %s for %s: %s not in quota",
+                    switch_key,
+                    coordinator.device_sn[-4:],
+                    state_key,
+                )
+                continue
             entities.append(
                 EcoFlowStreamSwitch(
                     coordinator=coordinator,


### PR DESCRIPTION
## Summary

Follow-up to #46 / issue #45. The AC2 Switch on Stream Ultra X was still failing with `API error (code 8524): Validation failed, Please check your param: cfgRelay3Onoff` even after v1.10.4 — the EcoFlow BKW docs confirm our payload format is exactly correct, but also spell out the actual root cause:

> *"In BKW systems with multiple devices, the parameters for the AC1 switch and AC2 switch are the serial number of the corresponding devices. For all other commands, you will first need to use this API to obtain the main device serial number."*

So in a multi-device BKW system, AC1 and AC2 can live on different physical devices, and sending `cfgRelay3Onoff` to a device that does not own relay3 is rejected by the REST API. This PR lands the defensive minimum fix:

- **Skip creating Stream Ultra X switch entities when the corresponding state key is missing from `/quota/all`.** If the device does not report `relay2Onoff`, `relay3Onoff`, or `feedGridMode`, we do not expose the no-op switch in the UI — so users never hit the 8524 validation error on AC2 when their device physically does not own that relay.
- Logs a `Skipping Stream switch ac2_output for … : relay3Onoff not in quota` line so multi-device users can see why an entity is missing.

Full multi-device BKW routing (resolve main SN via `/iot-open/sign/device/system/main/sn`, discover device list, and route AC1/AC2 commands to the device that owns each relay) will land as a separate enhancement — it needs a testbed with at least two stacked Stream Ultra X devices.

Release: **v1.10.5**, CHANGELOG updated.

## Test plan

- [ ] Single-device Stream Ultra X with both AC1 and AC2: both switches appear and toggle cleanly
- [ ] Single-device Stream Ultra X reporting `relay3Onoff: false` but no AC2 hardware: AC2 entity is not created (previously hit 8524)
- [ ] Multi-device BKW: on the device whose quota lacks `relay3Onoff`, AC2 entity is skipped; on the device that owns it, AC2 toggles still work
- [ ] Confirm `feedGridMode` entity is still created for single-device (state key is present in quota per docs)
- [ ] No regression on Delta Pro 3 / Delta 2 / Delta Pro Ultra (change is gated on `is_stream`)

https://claude.ai/code/session_015Bx1QrqMzcsbMUzaZZqAQv