### PR TITLE
fix: use boolean values for value_on and value_off

### DIFF
--- a/custom_components/ecoflow_api/switch.py
+++ b/custom_components/ecoflow_api/switch.py
@@ -279,6 +279,8 @@ STREAM_ULTRA_X_SWITCH_DEFINITIONS = {
         "param_key": "cfgRelay2Onoff",
         "icon_on": "mdi:power-socket",
         "icon_off": "mdi:power-socket-off",
+        "value_on": True,
+        "value_off": False,
         "device_class": SwitchDeviceClass.OUTLET,
     },
     "ac2_output": {
@@ -287,6 +289,8 @@ STREAM_ULTRA_X_SWITCH_DEFINITIONS = {
         "param_key": "cfgRelay3Onoff",
         "icon_on": "mdi:power-socket",
         "icon_off": "mdi:power-socket-off",
+        "value_on": True,
+        "value_off": False,
         "device_class": SwitchDeviceClass.OUTLET,
     },
     "feed_in_control": {


### PR DESCRIPTION
### Summary

EcoFlow API specifies a boolean true/false value for `cfgRelay2Onoff` and `cfgRelay3Onoff` for the Stream Ultra X. See https://developer-eu.ecoflow.com/us/document/bkw "AC1 switch" and "AC2 switch" sections:

```json
{
    "sn": "BK11ZEBB2H350011",
    "cmdId": 17,
    "cmdFunc": 254,
    "dirDest": 1,
    "dirSrc": 1,
    "dest": 2,
    "needAck": true,
    "params": {
        "cfgRelay2Onoff": true
    }
}
```

### Fix

Added `value_on` and `value_off` values to `STREAM_ULTRA_X_SWITCH_DEFINITIONS` using boolean `True` and `False`. This prevents the default overrides of 1 and 0 being sent, which resulted in a validation failed 8524 response:

```
2026-05-07 13:44:36.098 DEBUG (MainThread) [custom_components.ecoflow_api.coordinator] Sending command via REST API for 0639: params={'cfgRelay3Onoff': 0}
2026-05-07 13:44:36.098 DEBUG (MainThread) [custom_components.ecoflow_api.api] SET device quota: PUT payload={'sn': 'xxxxxxxxx', 'cmdId': 17, 'cmdFunc': 254, 'dirDest': 1, 'dirSrc': 1, 'dest': 2, 'needAck': True, 'params': {'cfgRelay3Onoff': 0}}
2026-05-07 13:44:36.134 ERROR (MainThread) [custom_components.ecoflow_api.switch] Failed to set ac2_output to 0: API error (code 8524): Validation failed, Please check your param: cfgRelay3Onoff
2026-05-07 13:44:36.134 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140040795477056] Unexpected exception
```

Logs demonstrating a valid request/response after the fix is applied:

```
2026-05-07 14:02:56.833 DEBUG (MainThread) [custom_components.ecoflow_api.api] SET device quota: PUT payload={'sn': 'xxxxxxxxxx', 'cmdId': 17, 'cmdFunc': 254, 'dirDest': 1, 'dirSrc': 1, 'dest': 2, 'needAck': True, 'params': {'cfgRelay3Onoff': True}}
2026-05-07 14:02:56.872 DEBUG (MainThread) [custom_components.ecoflow_api.api] SET device quota: response={'code': '0', 'message': 'Success', 'eagleEyeTraceId': '', 'tid': ''}
2026-05-07 14:02:56.872 DEBUG (MainThread) [custom_components.ecoflow_api.coordinator] Command sent via REST API for 0639: response={'code': '0', 'message': 'Success', 'eagleEyeTraceId': '', 'tid': ''}
```