### PR TITLE
fix: make issue agent label setup idempotent

### DIFF
--- a/.github/workflows/codex-issue-agent.yml
+++ b/.github/workflows/codex-issue-agent.yml
@@ -44,9 +44,7 @@ jobs:
             local name="$1"
             local color="$2"
             local description="$3"
-            if ! gh label view "$name" >/dev/null 2>&1; then
-              gh label create "$name" --color "$color" --description "$description"
-            fi
+            gh label create "$name" --color "$color" --description "$description" --force
           }
           ensure_label "codex-ready" "5319e7" "Maintainer-approved issue for the Codex issue agent"
           ensure_label "needs-info" "d876e3" "Further information is required"


### PR DESCRIPTION
## Summary

- Replace unsupported `gh label view` usage with idempotent `gh label create --force`.
- Fixes the failed `Ensure triage labels exist` step from run 28637484196.

## Validation

- `npx --yes prettier --check .github/workflows/codex-issue-agent.yml`