### PR TITLE
chore: ignore issue agent runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,12 @@ venv.bak/
 # Temporary API response files
 api_response_*.json
 
+# GitHub issue-agent runtime artifacts
+codex-issue-agent-output.md
+issue-agent-comment.md
+issue-agent-context.json
+issue-agent-pr-body.md
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

- Ignore Codex issue-agent runtime artifacts so automated draft PR branches do not accidentally include them.

## Validation

- Manual diff review (`.gitignore` has no Prettier parser in this repo environment).